### PR TITLE
11: Permissions Setup

### DIFF
--- a/src/app/app/job-infos/[jobInfoId]/interviews/new/page.tsx
+++ b/src/app/app/job-infos/[jobInfoId]/interviews/new/page.tsx
@@ -5,12 +5,13 @@ import { getCurrentUser } from "@/services/clerk/lib/get-current-user";
 import { and, eq } from "drizzle-orm";
 import { Loader2 } from "lucide-react";
 import { cacheTag } from "next/dist/server/use-cache/cache-tag";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { Suspense } from "react";
 import { fetchAccessToken } from "hume";
 import { env } from "@/data/env/server";
 import { VoiceProvider } from "@humeai/voice-react";
 import { StartCall } from "./_start-call";
+import { canCreateInterview } from "@/features/interviews/permissions";
 
 export default async function NewInterviewPage({
   params,
@@ -37,6 +38,10 @@ async function SuspendedComponent({ jobInfoId }: { jobInfoId: string }) {
     allData: true,
   });
   if (userId == null || user == null) return redirectToSignIn();
+
+  if (!(await canCreateInterview())) {
+    return redirect("/app/upgrade");
+  }
 
   const jobInfo = await getJobInfo(jobInfoId, userId);
   if (jobInfo == null) return notFound();

--- a/src/app/app/upgrade/page.tsx
+++ b/src/app/app/upgrade/page.tsx
@@ -1,0 +1,27 @@
+import { PricingTable } from "@/services/clerk/components/pricing-table";
+import { BackLink } from "@/components/backlink";
+import { AlertTriangle } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+
+export default function UpgradePage() {
+  return (
+    <div className="container py-4 max-w-6xl">
+      <div className="mb-4">
+        <BackLink href="/app">Dashboard</BackLink>
+      </div>
+
+      <div className="space-y-16">
+        <Alert variant="warning">
+          <AlertTriangle />
+          <AlertTitle>Plan Limit Reached</AlertTitle>
+          <AlertDescription>
+            You have reached the limit of your current plan. Please upgrade to
+            continue using all features.
+          </AlertDescription>
+        </Alert>
+
+        <PricingTable />
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,0 +1,68 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border px-4 py-3 text-sm grid has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] grid-cols-[0_1fr] has-[>svg]:gap-x-3 gap-y-0.5 items-start [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",
+  {
+    variants: {
+      variant: {
+        default: "bg-card text-card-foreground",
+        destructive:
+          "text-destructive bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-destructive/90",
+        warning:
+          "text-warning bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-warning/60",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
+
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      data-slot="alert"
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn(
+        "col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        "text-muted-foreground col-start-2 grid justify-items-start gap-1 text-sm [&_p]:leading-relaxed",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Alert, AlertTitle, AlertDescription };

--- a/src/features/interviews/actions.ts
+++ b/src/features/interviews/actions.ts
@@ -8,6 +8,8 @@ import { InterviewTable, JobInfoTable } from "@/drizzle/schema";
 import { and, eq } from "drizzle-orm";
 import { insertInterview, updateInterview as updateInterviewDb } from "./db";
 import { getInterviewIdTag } from "./db-cache";
+import { canCreateInterview } from "./permissions";
+import { PLAN_LIMIT_MESSAGE } from "@/lib/error-toast";
 
 export async function createInterview({
   jobInfoId,
@@ -24,6 +26,14 @@ export async function createInterview({
   }
 
   // TODO: Permissions
+
+  if (!(await canCreateInterview())) {
+    return {
+      error: true,
+      message: PLAN_LIMIT_MESSAGE,
+    };
+  }
+
   // TODO: Rate limit
 
   const jobInfo = await getJobInfo(jobInfoId, userId);

--- a/src/features/interviews/permissions.ts
+++ b/src/features/interviews/permissions.ts
@@ -1,0 +1,38 @@
+import { db } from "@/drizzle/db";
+import { InterviewTable, JobInfoTable } from "@/drizzle/schema";
+import { getCurrentUser } from "@/services/clerk/lib/get-current-user";
+import { hasPermission } from "@/services/clerk/lib/has-permission";
+import { and, count, eq, isNotNull } from "drizzle-orm";
+
+export async function canCreateInterview() {
+  return await Promise.any([
+    hasPermission("unlimited_interviews").then(
+      (bool) => bool || Promise.reject()
+    ),
+    Promise.all([hasPermission("1_interview"), getUserInterviewCount()]).then(
+      ([has, c]) => {
+        if (has && c < 1) return true;
+        return Promise.reject();
+      }
+    ),
+  ]).catch(() => false);
+}
+
+async function getUserInterviewCount() {
+  const { userId } = await getCurrentUser();
+  if (userId == null) return 0;
+
+  return getInterviewCount(userId);
+}
+
+async function getInterviewCount(userId: string) {
+  const [{ count: c }] = await db
+    .select({ count: count() })
+    .from(InterviewTable)
+    .innerJoin(JobInfoTable, eq(InterviewTable.jobInfoId, JobInfoTable.id))
+    .where(
+      and(eq(JobInfoTable.userId, userId), isNotNull(InterviewTable.humeChatId))
+    );
+
+  return c;
+}

--- a/src/services/clerk/lib/has-permission.ts
+++ b/src/services/clerk/lib/has-permission.ts
@@ -1,0 +1,13 @@
+import { auth } from "@clerk/nextjs/server";
+
+type Permission =
+  | "unlimited_resume_analysis"
+  | "unlimited_interviews"
+  | "unlimited_questions"
+  | "1_interview"
+  | "5_questions";
+
+export async function hasPermission(permission: Permission) {
+  const { has } = await auth();
+  return has({ feature: permission });
+}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds plan-based permissions for creating interviews. Users at their limit are redirected to a new Upgrade page with a clear warning.

- New Features
  - Permission check: canCreateInterview uses Clerk features (unlimited_interviews or 1_interview with <1 completed interview), counting only interviews with a humeChatId.
  - Enforcement: createInterview returns PLAN_LIMIT_MESSAGE; the New Interview page redirects to /app/upgrade when blocked.
  - Upgrade flow: New /app/upgrade page with a PricingTable and a warning banner.
  - UI: New reusable Alert component with default, destructive, and warning variants.

<!-- End of auto-generated description by cubic. -->

